### PR TITLE
cleanup(link): remove unused dependencies and add directive suffix

### DIFF
--- a/libs/angular-routing/src/index.ts
+++ b/libs/angular-routing/src/index.ts
@@ -2,7 +2,8 @@
  * Public API Surface of router
  */
 
-export * from './lib/link-active';
+export * from './lib/link-active.directive';
+export * from './lib/link-to.directive';
 export * from './lib/route-component.directive';
 export * from './lib/router.service';
 export * from './lib/router.component';
@@ -10,5 +11,4 @@ export * from './lib/route';
 export * from './lib/route.component';
 export * from './lib/router.module';
 export * from './lib/route-params.service';
-export * from './lib/link.component';
 export * from './lib/url-parser';

--- a/libs/angular-routing/src/lib/link-active.directive.ts
+++ b/libs/angular-routing/src/lib/link-active.directive.ts
@@ -11,7 +11,7 @@ import {
   QueryList,
   Renderer2
 } from '@angular/core';
-import { LinkToDirective } from './link-to.directive';
+import { LinkTo } from './link-to.directive';
 import { Router } from './router.service';
 import { combineLatest, of, Subject, Subscription } from 'rxjs';
 import { map, mapTo, startWith, takeUntil } from 'rxjs/operators';
@@ -25,7 +25,7 @@ export const LINK_ACTIVE_OPTIONS: LinkActiveOptions = {
 };
 
 /**
- * The LinkActiveDirective directive toggles classes on elements that contain an active linkTo directive
+ * The LinkActive directive toggles classes on elements that contain an active linkTo directive
  *
  * <a linkActive="active" linkTo="/home/page">Home Page</a>
  * <ol>
@@ -35,8 +35,8 @@ export const LINK_ACTIVE_OPTIONS: LinkActiveOptions = {
  * </ol>
  */
 @Directive({ selector: '[linkActive]' })
-export class LinkActiveDirective implements AfterContentInit, OnDestroy, OnChanges {
-  @ContentChildren(LinkToDirective, { descendants: true }) public links: QueryList<LinkToDirective>;
+export class LinkActive implements AfterContentInit, OnDestroy, OnChanges {
+  @ContentChildren(LinkTo, { descendants: true }) public links: QueryList<LinkTo>;
   @Input('linkActive') activeClass = 'active';
   @Input() activeOptions: LinkActiveOptions;
   private _activeOptions: LinkActiveOptions = { exact: true };
@@ -50,7 +50,7 @@ export class LinkActiveDirective implements AfterContentInit, OnDestroy, OnChang
     @Optional()
     @Inject(LINK_ACTIVE_OPTIONS)
     private defaultActiveOptions: LinkActiveOptions,
-    @Optional() private link: LinkToDirective
+    @Optional() private link: LinkTo
   ) { }
 
   ngAfterContentInit() {

--- a/libs/angular-routing/src/lib/link-active.directive.ts
+++ b/libs/angular-routing/src/lib/link-active.directive.ts
@@ -1,20 +1,20 @@
 import {
   AfterContentInit,
+  ContentChildren,
   Directive,
   ElementRef,
-  Input,
-  OnDestroy,
-  QueryList,
-  Renderer2,
-  Optional,
   Inject,
-  ContentChildren,
-  EventEmitter
+  Input,
+  OnChanges,
+  OnDestroy,
+  Optional,
+  QueryList,
+  Renderer2
 } from '@angular/core';
-import { LinkTo } from './link.component';
+import { LinkToDirective } from './link-to.directive';
 import { Router } from './router.service';
-import { from, Subject, Subscription, EMPTY, of, merge, combineLatest } from 'rxjs';
-import { mergeAll, map, withLatestFrom, takeUntil, startWith, switchMapTo, mapTo, mergeMap, tap, combineAll, toArray, switchMap, switchAll } from 'rxjs/operators';
+import { combineLatest, of, Subject, Subscription } from 'rxjs';
+import { map, mapTo, startWith, takeUntil } from 'rxjs/operators';
 
 export interface LinkActiveOptions {
   exact: boolean;
@@ -25,7 +25,7 @@ export const LINK_ACTIVE_OPTIONS: LinkActiveOptions = {
 };
 
 /**
- * The LinkActive directive toggles classes on elements that contain an active linkTo directive
+ * The LinkActiveDirective directive toggles classes on elements that contain an active linkTo directive
  *
  * <a linkActive="active" linkTo="/home/page">Home Page</a>
  * <ol>
@@ -35,9 +35,9 @@ export const LINK_ACTIVE_OPTIONS: LinkActiveOptions = {
  * </ol>
  */
 @Directive({ selector: '[linkActive]' })
-export class LinkActive implements AfterContentInit, OnDestroy {
-  @ContentChildren(LinkTo, { descendants: true }) public links: QueryList<LinkTo>;
-  @Input('linkActive') activeClass: string = 'active';
+export class LinkActiveDirective implements AfterContentInit, OnDestroy, OnChanges {
+  @ContentChildren(LinkToDirective, { descendants: true }) public links: QueryList<LinkToDirective>;
+  @Input('linkActive') activeClass = 'active';
   @Input() activeOptions: LinkActiveOptions;
   private _activeOptions: LinkActiveOptions = { exact: true };
   private _destroy$ = new Subject();
@@ -50,7 +50,7 @@ export class LinkActive implements AfterContentInit, OnDestroy {
     @Optional()
     @Inject(LINK_ACTIVE_OPTIONS)
     private defaultActiveOptions: LinkActiveOptions,
-    @Optional() private link: LinkTo
+    @Optional() private link: LinkToDirective
   ) { }
 
   ngAfterContentInit() {
@@ -89,7 +89,7 @@ export class LinkActive implements AfterContentInit, OnDestroy {
   }
 
   checkActive(linkHrefs: string[], path: string) {
-    let active = linkHrefs.reduce((isActive, current) => {
+    const active = linkHrefs.reduce((isActive, current) => {
       const [href] = current.split('?');
 
       if (this._activeOptions.exact) {
@@ -105,7 +105,7 @@ export class LinkActive implements AfterContentInit, OnDestroy {
   }
 
   updateClasses(active: boolean) {
-    let activeClasses = this.activeClass.split(' ');
+    const activeClasses = this.activeClass.split(' ');
     activeClasses.forEach((activeClass) => {
       if (active) {
         this.renderer.addClass(this.element.nativeElement, activeClass);

--- a/libs/angular-routing/src/lib/link-to.directive.ts
+++ b/libs/angular-routing/src/lib/link-to.directive.ts
@@ -12,7 +12,7 @@ import { Params } from './route-params.service';
 const DEFAULT_TARGET = '_self';
 
 /**
- * The LinkToDirective directive links to routes in your app
+ * The LinkTo directive links to routes in your app
  *
  * Links are pushed to the `Router` service to trigger a route change.
  * Query params can be represented as an object or a string of names/values
@@ -21,7 +21,7 @@ const DEFAULT_TARGET = '_self';
  * <a [linkTo]="'/pages' + page.id">Page 1</a>
  */
 @Directive({ selector: 'a[linkTo]' })
-export class LinkToDirective {
+export class LinkTo {
   @Input() target = DEFAULT_TARGET;
   @HostBinding('href') linkHref: string;
 

--- a/libs/angular-routing/src/lib/link-to.directive.ts
+++ b/libs/angular-routing/src/lib/link-to.directive.ts
@@ -60,9 +60,9 @@ export class LinkToDirective {
   }
 
   private _updateHref() {
-    let path = this._cleanUpHref(this._href);
+    const path = this._cleanUpHref(this._href);
 
-    let url = this.router.serializeUrl(path, this._query, this._hash);
+    const url = this.router.serializeUrl(path, this._query, this._hash);
     this.linkHref = url;
 
     this.hrefUpdated.emit(this.linkHref);
@@ -72,18 +72,13 @@ export class LinkToDirective {
    * Determines whether the click event happened with a combination of other keys
    */
   private _comboClick(event) {
-    let buttonEvent = event.which || event.button;
+    const buttonEvent = event.which || event.button;
 
     return buttonEvent > 1 || event.ctrlKey || event.metaKey || event.shiftKey;
   }
 
   private _cleanUpHref(href: string = ''): string {
-    // Check for trailing slashes in the path
-    while (href.length > 1 && href.substr(-1) === '/') {
-      // Remove trailing slashes
-      href = href.substring(0, href.length - 1);
-    }
-
-    return href;
+    // Trim whitespaces and remove trailing slashes
+    return href.trim().replace(/[\/]+$/, '')
   }
 }

--- a/libs/angular-routing/src/lib/link-to.directive.ts
+++ b/libs/angular-routing/src/lib/link-to.directive.ts
@@ -9,6 +9,8 @@ import {
 import { Router } from './router.service';
 import { Params } from './route-params.service';
 
+const DEFAULT_TARGET = '_self';
+
 /**
  * The LinkToDirective directive links to routes in your app
  *
@@ -20,7 +22,7 @@ import { Params } from './route-params.service';
  */
 @Directive({ selector: 'a[linkTo]' })
 export class LinkToDirective {
-  @Input() target: string;
+  @Input() target = DEFAULT_TARGET;
   @HostBinding('href') linkHref: string;
 
   @Input() set linkTo(href: string) {
@@ -52,7 +54,7 @@ export class LinkToDirective {
    */
   @HostListener('click', ['$event'])
   onClick(event: any) {
-    if (!this._comboClick(event) && !this.target) {
+    if (!this._comboClick(event) && this.target === DEFAULT_TARGET) {
       this.router.go(this._href, this._query, this._hash);
 
       event.preventDefault();

--- a/libs/angular-routing/src/lib/link-to.directive.ts
+++ b/libs/angular-routing/src/lib/link-to.directive.ts
@@ -10,7 +10,7 @@ import { Router } from './router.service';
 import { Params } from './route-params.service';
 
 /**
- * The LinkTo directive links to routes in your app
+ * The LinkToDirective directive links to routes in your app
  *
  * Links are pushed to the `Router` service to trigger a route change.
  * Query params can be represented as an object or a string of names/values
@@ -19,7 +19,7 @@ import { Params } from './route-params.service';
  * <a [linkTo]="'/pages' + page.id">Page 1</a>
  */
 @Directive({ selector: 'a[linkTo]' })
-export class LinkTo {
+export class LinkToDirective {
   @Input() target: string;
   @HostBinding('href') linkHref: string;
 

--- a/libs/angular-routing/src/lib/link-to.directive.ts
+++ b/libs/angular-routing/src/lib/link-to.directive.ts
@@ -60,10 +60,9 @@ export class LinkToDirective {
   }
 
   private _updateHref() {
-    const path = this._cleanUpHref(this._href);
+    const href = this._cleanUpHref(this._href);
 
-    const url = this.router.serializeUrl(path, this._query, this._hash);
-    this.linkHref = url;
+    this.linkHref = this.router.serializeUrl(href, this._query, this._hash);
 
     this.hrefUpdated.emit(this.linkHref);
   }

--- a/libs/angular-routing/src/lib/router.module.ts
+++ b/libs/angular-routing/src/lib/router.module.ts
@@ -8,8 +8,8 @@ import {
 import { RouterComponent } from './router.component';
 import { RouteComponent } from './route.component';
 import { RouteComponentTemplate } from './route-component.directive';
-import { LinkActive } from './link-active';
-import { LinkTo } from './link.component';
+import { LinkActiveDirective } from './link-active.directive';
+import { LinkToDirective } from './link-to.directive';
 import { UrlParser } from './url-parser';
 import { QueryParams } from './route-params.service';
 import { Router } from './router.service';
@@ -17,8 +17,8 @@ import { Router } from './router.service';
 export const components = [
   RouterComponent,
   RouteComponent,
-  LinkActive,
-  LinkTo,
+  LinkActiveDirective,
+  LinkToDirective,
   RouteComponentTemplate,
 ];
 

--- a/libs/angular-routing/src/lib/router.module.ts
+++ b/libs/angular-routing/src/lib/router.module.ts
@@ -8,8 +8,8 @@ import {
 import { RouterComponent } from './router.component';
 import { RouteComponent } from './route.component';
 import { RouteComponentTemplate } from './route-component.directive';
-import { LinkActiveDirective } from './link-active.directive';
-import { LinkToDirective } from './link-to.directive';
+import { LinkActive } from './link-active.directive';
+import { LinkTo } from './link-to.directive';
 import { UrlParser } from './url-parser';
 import { QueryParams } from './route-params.service';
 import { Router } from './router.service';
@@ -17,8 +17,8 @@ import { Router } from './router.service';
 export const components = [
   RouterComponent,
   RouteComponent,
-  LinkActiveDirective,
-  LinkToDirective,
+  LinkActive,
+  LinkTo,
   RouteComponentTemplate,
 ];
 


### PR DESCRIPTION
These should probably be rebased instead of being squashed since each commit is targeting different improvement point in linkTo directive.