### PR TITLE
chore(package): allow angular v10 as peer dependency

### DIFF
--- a/libs/angular-routing/package.json
+++ b/libs/angular-routing/package.json
@@ -18,9 +18,9 @@
   },
   "homepage": "https://github.com/brandonroberts/angular-routing#readme",
   "peerDependencies": {
-    "@angular/common": "^9.0.0",
-    "@angular/core": "^9.0.0",
-    "rxjs": "^6.5.3"
+    "@angular/common": ">=9.0.0",
+    "@angular/core": ">=9.0.0",
+    "rxjs": ">=6.5.3"
   },
   "dependencies": {
     "path-to-regexp": "^6.1.0",


### PR DESCRIPTION
At the moment `npm i` complains if you try to add `angular-routing` to ng10 project as it expects v9 versions of common and core.