### PR TITLE
fix(parser): pass base to URL only when value is provided

### DIFF
--- a/libs/angular-routing/src/lib/url-parser.ts
+++ b/libs/angular-routing/src/lib/url-parser.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class UrlParser {
   parse(url: string, base?: string | URL): URL {
-    return new URL(url, base);
+    if (base) {
+      return new URL(url, base);
+    }
+    return new URL(url);
   }
 
   joinUrls(currentUrl: string, url: string): string {


### PR DESCRIPTION
On Safari attempting to pass `base` as `undefined` results with `TypeError` as seen on https://responsive-ng-router.netlify.app.
Based on type definition for URL, `base` property is optional and of type `string | URL`. While most browsers consider passing undefined and omitting the property same, Safari is somewhat strict in this matter and throws an exception.