### PR TITLE
fix(router-component): enable `exact` option for params parsing on setRoute

### DIFF
--- a/libs/angular-routing/src/lib/router.component.ts
+++ b/libs/angular-routing/src/lib/router.component.ts
@@ -86,7 +86,9 @@ export class RouterComponent {
   }
 
   setRoute(url: string, route: Route) {
-    const pathInfo = match(this.normalizePath(route.path))(url);
+    const pathInfo = match(this.normalizePath(route.path), {
+      end: route.options.exact,
+    })(url);
     this.basePath = route.path;
 
     const routeParams: Params = pathInfo ? pathInfo.params : {};


### PR DESCRIPTION
The `exact` option is not considered on params parsing in `RouterComponent`'s `setRoute` method leading to loss of params in parent components in the nested routes architecture.

The example can be seen on [https://recursive-ng-router.netlify.app/meeroslav/juanpicado/dianmorales](https://recursive-ng-router.netlify.app/meeroslav/juanpicado/dianmorales) (source: [https://github.com/meeroslav/recursive-router-demo](https://github.com/meeroslav/recursive-router-demo)). Only the last child component is getting a param.