### PR TITLE
feat(route-component): provide matched path in route component

### DIFF
--- a/libs/angular-routing/src/lib/route-params.service.ts
+++ b/libs/angular-routing/src/lib/route-params.service.ts
@@ -4,6 +4,8 @@ export interface Params {
   [param: string]: any;
 }
 
+export class RoutePath<T extends string = string> extends Observable<T> {}
+
 export class RouteParams<T extends Params = Params> extends Observable<T> {}
 
 export class QueryParams<T extends Params = Params> extends Observable<T> {}

--- a/libs/angular-routing/src/lib/route.ts
+++ b/libs/angular-routing/src/lib/route.ts
@@ -19,6 +19,7 @@ export interface RouteOptions {
 export interface ActiveRoute {
   route: Route;
   params: Params;
+  path: string;
 }
 
 export interface ModuleWithRoute {

--- a/libs/angular-routing/src/lib/router.component.ts
+++ b/libs/angular-routing/src/lib/router.component.ts
@@ -73,7 +73,7 @@ export class RouterComponent implements OnInit, OnDestroy {
           }
 
           if (!routeToRender) {
-            this.setActiveRoute({ route: null, params: {} });
+            this.setActiveRoute({ route: null, params: {}, path: '' });
           }
         }),
         takeUntil(this.destroy$)
@@ -98,7 +98,8 @@ export class RouterComponent implements OnInit, OnDestroy {
     this.basePath = route.path;
 
     const routeParams: Params = pathInfo ? pathInfo.params : {};
-    this.setActiveRoute({ route, params: routeParams || {} });
+    const path: string = pathInfo ? pathInfo.path : '';
+    this.setActiveRoute({ route, params: routeParams || {}, path });
   }
 
   registerRoute(route: Route) {


### PR DESCRIPTION
Provide the possibility to get the matched path in the `RouteComponent`, similar to params.
This enables the user to navigate back in the complex nested routes hierarchy with ease.

### Example

app.component:
```html
<router>
  <route path="/:username" [exact]="false">
    <app-user *routeComponent></app-user>
  </route>
  <route path="/" redirectTo="/johndoe"></route>
</router>
```
app.user:
```html
<router>
  <route path="/family" [exact]="false">
    <app-family *routeComponent></app-family>
  </route>
  <route path="/">
    <div *routeComponent>
      ...some info about the user...
    </div>
  </route>
</router>
<a [linkTo]="path$ | async">{{ username$ | async }}</a>
```
app.user.ts:
```ts
export class AppUserComponent implements OnInit {
  username$: Observable<string>;
  path$: Observable<string>;

  constructor(
    private readonly routeParams$: RouteParams<{ username: string }>,
    private readonly routePath$: RoutePath<string>,
  ) { }

  ngOnInit(): void {
    this.path$ = this.routePath$;
    this.username$ = this.routeParams$.pipe(map(params => params.username));
  }
}
```

If we are at e.g. `/janedoe/family/...` we can easily go back to `/janedoe`.