### PR TITLE
feat(router): provide access to all route params via router service. resolves #39

### DIFF
--- a/apps/getting-started/src/app/app.component.html
+++ b/apps/getting-started/src/app/app.component.html
@@ -2,7 +2,7 @@
 
 <div class="container">
   <router>
-    <route path="/products/:productId">
+    <route path="/products/:productId" [exact]="false">
       <app-product-details *routeComponent></app-product-details>
     </route>
     <route path="/cart">
@@ -17,7 +17,7 @@
   </router>
 </div>
 
-<!-- 
+<!--
 Copyright Google LLC. All Rights Reserved.
 Use of this source code is governed by an MIT-style license that
 can be found in the LICENSE file at http://angular.io/license

--- a/apps/getting-started/src/app/product-details/product-details.component.html
+++ b/apps/getting-started/src/app/product-details/product-details.component.html
@@ -8,7 +8,18 @@
   <button (click)="addToCart(product)">Buy</button>
 </div>
 
-<!-- 
+<router>
+  <route path="products/:temp" [exact]="false">
+    <app-product-details *routeComponent></app-product-details>
+  </route>
+  <route path="">
+    <a linkTo="products/2" class="button fancy-button" *routerComponent>
+      Got to product 2
+    </a>
+  </route>
+</router>
+
+<!--
 Copyright Google LLC. All Rights Reserved.
 Use of this source code is governed by an MIT-style license that
 can be found in the LICENSE file at http://angular.io/license

--- a/apps/getting-started/src/app/product-details/product-details.component.ts
+++ b/apps/getting-started/src/app/product-details/product-details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { products } from '../products';
 import { CartService } from '../cart.service';
-import { RouteParams } from 'angular-routing';
+import { RouteParams, Router } from 'angular-routing';
 
 @Component({
   selector: 'app-product-details',
@@ -14,13 +14,17 @@ export class ProductDetailsComponent implements OnInit {
 
   constructor(
     private routeParams$: RouteParams<{ productId: string }>,
-    private cartService: CartService
+    private cartService: CartService,
+    private router: Router
   ) {}
 
   ngOnInit() {
     this.routeParams$.subscribe((params) => {
       this.product = products[+params.productId];
     });
+    this.router.routeParams$.subscribe((params) =>
+      console.log('Router params', params)
+    );
   }
 
   addToCart(product) {

--- a/libs/angular-routing/src/index.ts
+++ b/libs/angular-routing/src/index.ts
@@ -10,5 +10,5 @@ export * from './lib/router.component';
 export * from './lib/route';
 export * from './lib/route.component';
 export * from './lib/router.module';
-export * from './lib/route-params.service';
+export * from './lib/route-params';
 export * from './lib/url-parser';

--- a/libs/angular-routing/src/lib/link-to.directive.ts
+++ b/libs/angular-routing/src/lib/link-to.directive.ts
@@ -7,7 +7,7 @@ import {
   EventEmitter,
 } from '@angular/core';
 import { Router } from './router.service';
-import { Params } from './route-params.service';
+import { Params } from './route-params';
 
 const DEFAULT_TARGET = '_self';
 

--- a/libs/angular-routing/src/lib/route-params.ts
+++ b/libs/angular-routing/src/lib/route-params.ts
@@ -9,3 +9,9 @@ export class RoutePath<T extends string = string> extends Observable<T> {}
 export class RouteParams<T extends Params = Params> extends Observable<T> {}
 
 export class QueryParams<T extends Params = Params> extends Observable<T> {}
+
+export function compareParams(previous: Params, current: Params): boolean {
+  return (
+    previous === current || JSON.stringify(previous) === JSON.stringify(current)
+  );
+}

--- a/libs/angular-routing/src/lib/route.component.ts
+++ b/libs/angular-routing/src/lib/route.component.ts
@@ -24,7 +24,7 @@ import {
 } from 'rxjs/operators';
 
 import { Load, Route, RouteOptions } from './route';
-import { Params, RouteParams, RoutePath } from './route-params.service';
+import { Params, RouteParams, RoutePath } from './route-params';
 import { RouterComponent } from './router.component';
 import { Router } from './router.service';
 

--- a/libs/angular-routing/src/lib/route.ts
+++ b/libs/angular-routing/src/lib/route.ts
@@ -1,6 +1,6 @@
 import { Type, NgModuleFactory } from '@angular/core';
 
-import { Params } from './route-params.service';
+import { Params } from './route-params';
 
 export type Load = () => Promise<NgModuleFactory<any> | Type<any> | any>;
 

--- a/libs/angular-routing/src/lib/router.component.ts
+++ b/libs/angular-routing/src/lib/router.component.ts
@@ -19,7 +19,8 @@ import { pathToRegexp, match } from 'path-to-regexp';
 
 import { Route, ActiveRoute } from './route';
 import { Router } from './router.service';
-import { Params } from './route-params.service';
+import { Params } from './route-params';
+import { compareParams } from './route-params';
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -30,7 +31,9 @@ export class RouterComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject();
 
   private _activeRoute$ = new BehaviorSubject<ActiveRoute>(null);
-  readonly activeRoute$ = this._activeRoute$.pipe(distinctUntilChanged());
+  readonly activeRoute$ = this._activeRoute$.pipe(
+    distinctUntilChanged(this.compareActiveRoutes)
+  );
 
   private _routes$ = new BehaviorSubject<Route[]>([]);
   readonly routes$ = this._routes$.pipe(
@@ -121,6 +124,21 @@ export class RouterComponent implements OnInit, OnDestroy {
 
   private normalizePath(path: string) {
     return this.location.normalize(path);
+  }
+
+  private compareActiveRoutes(
+    previous: ActiveRoute,
+    current: ActiveRoute
+  ): boolean {
+    if (previous === current) {
+      return true;
+    }
+    return (
+      previous.path === current.path &&
+      compareParams(previous.params, current.params) &&
+      previous.route.path === current.route.path &&
+      previous.route.options.exact === current.route.options.exact
+    );
   }
 
   ngOnDestroy() {

--- a/libs/angular-routing/src/lib/router.component.ts
+++ b/libs/angular-routing/src/lib/router.component.ts
@@ -81,16 +81,6 @@ export class RouterComponent implements OnInit, OnDestroy {
       .subscribe();
   }
 
-  findRouteMatch(route: Route, url: string) {
-    const matchedRoute = route.matcher ? route.matcher.exec(url) : null;
-
-    if (matchedRoute) {
-      return matchedRoute;
-    }
-
-    return null;
-  }
-
   setRoute(url: string, route: Route) {
     const pathInfo = match(this.normalizePath(route.path), {
       end: route.options.exact,
@@ -100,6 +90,7 @@ export class RouterComponent implements OnInit, OnDestroy {
     const routeParams: Params = pathInfo ? pathInfo.params : {};
     const path: string = pathInfo ? pathInfo.path : '';
     this.setActiveRoute({ route, params: routeParams || {}, path });
+    this.router.updateRouteParams(routeParams);
   }
 
   registerRoute(route: Route) {
@@ -114,11 +105,21 @@ export class RouterComponent implements OnInit, OnDestroy {
     return route;
   }
 
-  setActiveRoute(active: ActiveRoute) {
+  private findRouteMatch(route: Route, url: string) {
+    const matchedRoute = route.matcher ? route.matcher.exec(url) : null;
+
+    if (matchedRoute) {
+      return matchedRoute;
+    }
+
+    return null;
+  }
+
+  private setActiveRoute(active: ActiveRoute) {
     this._activeRoute$.next(active);
   }
 
-  normalizePath(path: string) {
+  private normalizePath(path: string) {
     return this.location.normalize(path);
   }
 

--- a/libs/angular-routing/src/lib/router.module.ts
+++ b/libs/angular-routing/src/lib/router.module.ts
@@ -11,7 +11,7 @@ import { RouteComponentTemplate } from './route-component.directive';
 import { LinkActive } from './link-active.directive';
 import { LinkTo } from './link-to.directive';
 import { UrlParser } from './url-parser';
-import { QueryParams } from './route-params.service';
+import { QueryParams } from './route-params';
 import { Router } from './router.service';
 
 export const components = [

--- a/libs/angular-routing/src/lib/router.service.ts
+++ b/libs/angular-routing/src/lib/router.service.ts
@@ -7,7 +7,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
 import * as queryString from 'query-string';
 
 import { UrlParser } from './url-parser';
-import { Params } from './route-params.service';
+import { compareParams, Params } from './route-params';
 
 @Injectable({
   providedIn: 'root',
@@ -18,11 +18,13 @@ export class Router {
 
   private _routeParams$ = new BehaviorSubject<Params>({});
   readonly routeParams$ = this._routeParams$.pipe(
-    distinctUntilChanged((x, y) => JSON.stringify(x) === JSON.stringify(y))
+    distinctUntilChanged(compareParams)
   );
 
   private _queryParams$ = new BehaviorSubject<Params>({});
-  readonly queryParams$ = this._queryParams$.pipe(distinctUntilChanged());
+  readonly queryParams$ = this._queryParams$.pipe(
+    distinctUntilChanged(compareParams)
+  );
 
   private _hash$ = new BehaviorSubject<string>('');
   readonly hash$ = this._hash$.pipe(distinctUntilChanged());

--- a/libs/angular-routing/src/lib/router.service.ts
+++ b/libs/angular-routing/src/lib/router.service.ts
@@ -16,6 +16,11 @@ export class Router {
   private _url$ = new BehaviorSubject<string>(this.location.path());
   readonly url$ = this._url$.pipe(distinctUntilChanged());
 
+  private _routeParams$ = new BehaviorSubject<Params>({});
+  readonly routeParams$ = this._routeParams$.pipe(
+    distinctUntilChanged((x, y) => JSON.stringify(x) === JSON.stringify(y))
+  );
+
   private _queryParams$ = new BehaviorSubject<Params>({});
   readonly queryParams$ = this._queryParams$.pipe(distinctUntilChanged());
 
@@ -56,6 +61,10 @@ export class Router {
       (queryParams ? `?${queryString.stringify(queryParams)}` : '') +
       `${hash ? '#' + hash : ''}`
     );
+  }
+
+  updateRouteParams(params: Params) {
+    this._routeParams$.next(params);
   }
 
   getExternalUrl(url: string) {


### PR DESCRIPTION
#### Problem:
Expose route params from the router component back to router service to have it available for all components.

#### The tricky part: 
Since routes are not configured in central configuration (like in @angular/router) but rather loaded and parsed asynchronously from components, the `routeParams` will change until parsing has been fully finished.

#### Unrelated bug fixed separately (found in router component and service):
`distinctUntilChanged` does value referential comparison. It works nicely for strings, but for objects (such as `Params`) a custom comparison function must be provided e.g.:
```ts
const paramsCompare = (x,y) = x === y || JSON.stringify(x) === JSON.stringify(y)
```