### PR TITLE
build: remove prod flag from the build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points",
     "nx": "nx",
     "start": "ng serve",
-    "build": "ng build angular-routing --prod",
+    "build": "ng build angular-routing",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "test": "ng test angular-routing",
     "lint": "nx workspace-lint && ng lint",


### PR DESCRIPTION
This flag is not handled by the project's schematics